### PR TITLE
Some mild refactoring and renaming. 1-2% faster it seems, though the …

### DIFF
--- a/jaxnerf/configs/blender.yaml
+++ b/jaxnerf/configs/blender.yaml
@@ -1,8 +1,8 @@
 dataset: blender
 image_batching: false
 factor: 0
-n_samples: 64
-n_fine_samples: 128
+num_coarse_samples: 64
+num_fine_samples: 128
 use_viewdirs: true
 white_bkgd: true
 batch_size: 4096

--- a/jaxnerf/configs/demo.yaml
+++ b/jaxnerf/configs/demo.yaml
@@ -1,8 +1,8 @@
 dataset: blender
 image_batching: false
 factor: 0
-n_samples: 64
-n_fine_samples: 128
+num_coarse_samples: 64
+num_fine_samples: 128
 use_viewdirs: true
 white_bkgd: true
 batch_size: 1024

--- a/jaxnerf/configs/llff.yaml
+++ b/jaxnerf/configs/llff.yaml
@@ -1,7 +1,7 @@
 dataset: llff
 image_batching: true
-n_samples: 64
-n_fine_samples: 128
+num_coarse_samples: 64
+num_fine_samples: 128
 use_viewdirs: true
 white_bkgd: false
 batch_size: 4096

--- a/jaxnerf/eval.py
+++ b/jaxnerf/eval.py
@@ -80,6 +80,7 @@ def main(unused_argv):
     if not FLAGS.eval_once:
       showcase_index = np.random.randint(0, dataset.size)
     for idx in range(dataset.size):
+      print(f"Evaluating {idx+1}/{dataset.size}")
       batch = next(dataset)
       pred_color, pred_disp, pred_acc = utils.render_image(
           state, batch, render_fn, rng, chunk=FLAGS.chunk)
@@ -95,7 +96,7 @@ def main(unused_argv):
         sq_diff = ((pred_color - batch["pixels"])**2).mean()
         psnr = utils.compute_psnr(sq_diff)
         sum_psnr = sum_psnr + float(psnr)
-        print("Test example {0:03d}: \n\tpsnr={1:.4f}".format(idx, psnr))
+        print(f"  PSNR = {psnr:.4f}")
       if FLAGS.save_output:
         utils.save_img(pred_color, path.join(out_dir, "{:03d}.png".format(idx)))
         utils.save_img(pred_disp[Ellipsis, 0],

--- a/jaxnerf/nerf/datasets.py
+++ b/jaxnerf/nerf/datasets.py
@@ -141,6 +141,8 @@ class Blender(Dataset):
 
   def _load_renderings(self, args):
     """Load images from disk."""
+    if args.render_path:
+      raise ValueError("render_path cannot be used for the blender dataset.")
     with utils.open_file(
         path.join(args.data_dir, "transforms_{}.json".format(self.split)),
         "r") as fp:


### PR DESCRIPTION
…goal is mostly tidyiness and future work. Specifics:

 - Avoiding unnecessary "raw" concatenations and separations, which speeds things up and allows for tidier code.
 - Independent handling of RGB/sigma activations, and allowing arbitrary command line activations that don't violate the image formation assumptions.
 - Rewriting the computation of disparity to be slightly more stable and efficient.
 - Renaming "alpha" to "sigma" when appropriate
 - Using different variable names for 3D RGB values and "composited" 2D RGB values.
 - renamed variables n_* to num_*
 - renamed variable num_samples to num_coarse_samples
 - Auto-formatting several files.
 - More informative summaries and command line printing.
 - Add a test that render_path is only used with llff (which would previously just cause eval to never terminate)

PiperOrigin-RevId: 349289774